### PR TITLE
Improve export logic, linting, docs and add tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
     "jest": true
   },
   "rules": {
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["react-app", "plugin:react/recommended"],
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "jest": true
+  },
+  "rules": {
+    "react/prop-types": "off"
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ npm run build  # build for production
 npm test     # run tests
 ```
 
+## Running tests
+
+Execute `npm test` to launch the Jest test runner. Use `npm test -- --watchAll=false` inside CI environments.
+
+## Contributing
+
+1. Fork the repository and create a new branch for your changes.
+2. Run `npm ci` to install dependencies and `npm run lint` to check code style.
+3. Submit a pull request with a clear description of your changes.
+
+## Features
+
+- Manage part information and inspection items.
+- Export populated data sheets to Excel based on the current application state.
+
 ## Project structure
 
 - `src/` - React components and features

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,9 @@
         "xlsx-populate": "^1.21.0"
       },
       "devDependencies": {
-        "gh-pages": "^6.3.0"
+        "eslint": "^8.56.0",
+        "gh-pages": "^6.3.0",
+        "prettier": "^3.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -13598,6 +13600,21 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "lint": "eslint src --ext js,jsx",
+    "format": "prettier --write \"src/**/*.{js,jsx}\"",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -45,6 +47,8 @@
     ]
   },
   "devDependencies": {
-    "gh-pages": "^6.3.0"
+    "gh-pages": "^6.3.0",
+    "eslint": "^8.56.0",
+    "prettier": "^3.1.0"
   }
 }

--- a/src/features/Export/__tests__/excelExporter.test.js
+++ b/src/features/Export/__tests__/excelExporter.test.js
@@ -1,0 +1,39 @@
+import { prepareExportRows } from '../excelExporter';
+
+const sampleItems = [
+  {
+    id: '1',
+    groupId: 'g1',
+    name: 'Hole Dia',
+    toleranceType: 'Radial',
+    nominal: '10',
+    usl: '10.5',
+    lsl: '9.5',
+    controlPlan: 'N/A',
+    method: 'Gauge',
+    sampleFreq: '1/shift',
+    reportingFreq: 'Monthly',
+    subitem: ''
+  },
+  {
+    id: '2',
+    groupId: 'g1',
+    name: 'Hole Dia',
+    toleranceType: 'Radial',
+    nominal: '10',
+    usl: '10.5',
+    lsl: '9.5',
+    controlPlan: 'N/A',
+    method: 'Gauge',
+    sampleFreq: '1/shift',
+    reportingFreq: 'Monthly',
+    subitem: 'X'
+  }
+];
+
+test('prepareExportRows maps items to excel rows', () => {
+  const rows = prepareExportRows(sampleItems);
+  expect(rows.length).toBe(2);
+  expect(rows[0][0]).toBe(1);
+  expect(rows[1][1]).toBe('Hole Dia - X');
+});

--- a/src/features/InspectionItems/__tests__/useGroupedItems.test.js
+++ b/src/features/InspectionItems/__tests__/useGroupedItems.test.js
@@ -1,0 +1,48 @@
+import { renderHook, act } from '@testing-library/react';
+import useGroupedItems from '../useGroupedItems';
+
+test('adds a single item when tolerance type has no subitems', () => {
+  const { result } = renderHook(() => useGroupedItems());
+  act(() => {
+    result.current.handleAddOrUpdate(
+      {
+        name: 'Item1',
+        toleranceType: 'Flatness',
+        nominal: '',
+        usl: '',
+        lsl: '',
+        controlPlan: 'N/A',
+        method: '',
+        sampleFreq: '',
+        reportingFreq: ''
+      },
+      [],
+      [],
+      () => {}
+    );
+  });
+  expect(result.current.items).toHaveLength(1);
+});
+
+test('adds subitems when tolerance type requires XY', () => {
+  const { result } = renderHook(() => useGroupedItems());
+  act(() => {
+    result.current.handleAddOrUpdate(
+      {
+        name: 'Item2',
+        toleranceType: 'Radial',
+        nominal: '',
+        usl: '',
+        lsl: '',
+        controlPlan: 'N/A',
+        method: '',
+        sampleFreq: '',
+        reportingFreq: ''
+      },
+      ['Radial'],
+      [],
+      () => {}
+    );
+  });
+  expect(result.current.items).toHaveLength(3);
+});


### PR DESCRIPTION
## Summary
- add ESLint/Prettier configuration
- refactor excel exporter to rely on React state
- add unit tests for exporter logic and custom hook
- document testing and contribution instructions

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685068f98fc0832b88a00c3d9e255a16